### PR TITLE
Add another typo form of required

### DIFF
--- a/genwords/additions.go
+++ b/genwords/additions.go
@@ -249,6 +249,7 @@ protototype->prototype
 publsih->publish
 quuery->query
 requried->required
+requiered->required
 retrived->retrieved
 ridiculus->ridiculous
 seperator->separator


### PR DESCRIPTION
Hi,

I've seen several times the word `required` misspelled as `requiered` over the last few months. Thought it would be a good fit to add in here.

Thanks,
Joseph
